### PR TITLE
Feature/fading restore and more

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+package-lock.json
+/.project

--- a/MMM-Volume.js
+++ b/MMM-Volume.js
@@ -24,7 +24,7 @@ Module.register("MMM-Volume", {
     upDownScale: 5,
     volumeOnStart: 10,
     fadeDelay: 200,
-
+    
     volumeText: "Vol: #VOLUME#%",
 
     telegramMessages: {
@@ -42,6 +42,10 @@ Module.register("MMM-Volume", {
       "ALSA" : {
         getVolumeScript: `amixer sget 'PCM' | awk -F"[][]" '{print ""$2""}' | grep %  | awk ' { gsub ( /[%]/, "" )`, //get 0~100
         setVolumeScript: `amixer sset -M 'PCM' #VOLUME#%`, //set 0~100
+      },
+      "HIFIBERRY-DAC" : {
+        getVolumeScript: `amixer sget 'Digital' | grep -E -o '[[:digit:]]+%' | head -n 1| sed 's/%//g'`, // get 0~100
+        setVolumeScript: `amixer sset -M 'Digital' #VOLUME#%`, // set 0~100
       }
     },
 

--- a/MMM-Volume.js
+++ b/MMM-Volume.js
@@ -14,11 +14,16 @@ Module.register("MMM-Volume", {
     // for RPI ALSA mixer
     //getVolumeScript: `amixer sget 'PCM' | awk -F"[][]" '{print ""$2""}' | grep %  | awk ' { gsub ( /[%]/, "" )`, //get 0~100
     //setVolumeScript: ` amixer sset 'PCM' *VOLUME*%`, //set 0~100
+    
+    // for RPI ALSA mixer with HiFiBerry AMP2
+    //getVolumeScript: 'amixer sget \'Digital\' | grep -E -o \'[[:digit:]]+%\' | head -n 1| sed \'s/%//g\'', // get 0~100
+    //setVolumeScript: 'amixer sset -M \'Digital\' #VOLUME#%', // set 0~100
 
     usePresetScript: "ALSA", // null or "OSX" or "ALSA", When set to `null`, `getVolumeScript` and `setVolumeScript` will be used directly.
     hideDelay: 2000, // 0 for showing always. over 0, After X millisec from showing, will be disappeared.
     upDownScale: 5,
     volumeOnStart: 10,
+    fadeDelay: 200,
 
     volumeText: "Vol: #VOLUME#%",
 
@@ -47,6 +52,7 @@ Module.register("MMM-Volume", {
       VOLUME_DOWN: "VOLUME_DOWN",
       VOLUME_STORE : "VOLUME_STORE",
       VOLUME_RESTORE : "VOLUME_RESTORE",
+      VOLUME_TOGGLE : "VOLUME_TOGGLE",
       CURRENT_VOLUME : "CURRENT_VOLUME",
     },
   },
@@ -66,7 +72,7 @@ Module.register("MMM-Volume", {
     this.sendSocketNotification("CONFIG", this.config)
   },
 
-  notificationReceived: function(noti, payload=null, sender) {
+  notificationReceived: function(noti, payload=null) {
     switch(noti) {
       case this.config.notifications.VOLUME_GET:
         this.sendSocketNotification(noti, payload)
@@ -75,26 +81,84 @@ Module.register("MMM-Volume", {
         this.sendSocketNotification(noti, payload)
         break
       case this.config.notifications.VOLUME_UP:
-        var vol = this.currentVolume + this.config.upDownScale
+        if (typeof payload.upDownScale !== 'undefined'){
+          var curUpDownScale = payload.upDownScale
+        } else {
+          var curUpDownScale = this.config.upDownScale
+        }
+        var vol = this.currentVolume + curUpDownScale
         if (vol > 100) vol = 100
         this.sendSocketNotification(this.config.notifications.VOLUME_SET, vol)
         break
       case this.config.notifications.VOLUME_DOWN:
-        var vol = this.currentVolume - this.config.upDownScale
+        if (typeof payload.upDownScale !== 'undefined'){
+          var curUpDownScale = payload.upDownScale
+        } else {
+          var curUpDownScale = this.config.upDownScale
+        }
+        var vol = this.currentVolume - curUpDownScale
         if (vol < 0) vol = 0
         this.sendSocketNotification(this.config.notifications.VOLUME_SET, vol)
         break
       case this.config.notifications.VOLUME_STORE:
-        this.storedVolume = this.currentVolume
-        if (payload) {
-          this.sendSocketNotification(this.config.notifications.VOLUME_SET, payload)
-        }
+        this.storeVolume(payload)
         break
       case this.config.notifications.VOLUME_RESTORE:
-        if (this.storedVolume !== null) {
-          this.sendSocketNotification(this.config.notifications.VOLUME_SET, this.storedVolume)
+        this.restoreVolume(payload)
+        break
+      case this.config.notifications.VOLUME_TOGGLE:
+        if(this.currentVolume === 0){
+          this.restoreVolume(payload)
+        } else {
+          this.storeVolume(0)
         }
         break
+    }
+  },
+
+  sleep: function (ms) {
+    return new Promise(resolve => setTimeout(resolve, ms));
+  },
+
+  storeVolume: function(value){
+    this.storedVolume = this.currentVolume
+    if (typeof value !== 'undefined') {
+      this.sendSocketNotification(this.config.notifications.VOLUME_SET, value)
+    }
+  },
+
+  restoreVolume: async function(options){
+    if (this.storedVolume !== null) {
+      if((typeof options.faded !== 'undefined') && (options.faded === true))
+      {
+        if (typeof options.upDownScale !== 'undefined'){
+          var curUpDownScale = options.upDownScale
+        } else {
+          var curUpDownScale = this.config.upDownScale
+        }
+
+        if(this.currentVolume < this.storedVolume){
+          while (this.currentVolume < this.storedVolume){
+            var newVolume = this.currentVolume + curUpDownScale
+            if(newVolume > this.storedVolume){
+              newVolume = this.storedVolume
+            }
+            this.sendSocketNotification(this.config.notifications.VOLUME_SET, newVolume)
+            await this.sleep(this.config.fadeDelay);
+          }
+        } else {
+          while (this.currentVolume > this.storedVolume){
+            var newVolume = this.currentVolume - curUpDownScale
+            if(newVolume < this.storedVolume){
+              newVolume = this.storedVolume
+            }
+            this.sendSocketNotification(this.config.notifications.VOLUME_SET, newVolume)
+            await this.sleep(this.config.fadeDelay);
+          }
+        }
+      } else {
+        this.sendSocketNotification(this.config.notifications.VOLUME_SET, this.storedVolume)
+      }
     }
   },
 

--- a/README.md
+++ b/README.md
@@ -68,6 +68,10 @@ git clone https://github.com/eouia/MMM-Volume
       "ALSA" : {
         getVolumeScript: `amixer sget 'PCM' | awk -F"[][]" '{print ""$2""}' | grep %  | awk ' { gsub ( /[%]/, "" )`, //get 0~100
         setVolumeScript: `amixer sset -M 'PCM' #VOLUME#%`, //set 0~100
+      },
+      "HIFIBERRY-DAC" : {
+        getVolumeScript: `amixer sget 'Digital' | grep -E -o '[[:digit:]]+%' | head -n 1| sed 's/%//g'`, // get 0~100
+        setVolumeScript: `amixer sset -M 'Digital' #VOLUME#%`, // set 0~100
       }
     },
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,9 @@ git clone https://github.com/eouia/MMM-Volume
     hideDelay: 2000,
     // After X milliseconds from showing, volume gain-meter will be disappeared.
 
+    fadeDelay: 200,
+    // If the volume is restored with a fade effect this time in milliseconds will be waited between to scales
+
     telegramMessages: {
       CUR_VOLUME : "Current Volume is *#VOLUME#*.",
       SET_VOLUME : "Setting Volume to *#VOLUME#*",
@@ -75,6 +78,7 @@ git clone https://github.com/eouia/MMM-Volume
       VOLUME_DOWN: "VOLUME_DOWN",
       VOLUME_STORE : "VOLUME_STORE",
       VOLUME_RESTORE : "VOLUME_RESTORE",
+      VOLUME_TOGGLE : "VOLUME_TOGGLE",
       CURRENT_VOLUME : "CURRENT_VOLUME",
     },
     // You can redefine notifications if you need.
@@ -91,10 +95,10 @@ git clone https://github.com/eouia/MMM-Volume
 |---|---|---|
 |VOLUME_GET | - | Getting current volume
 |VOLUME_SET | 0 - 100 | Setting Volume to `number`. 0 is mute and 100 is maximum
-|VOLUME_UP | - | Volume up by `upDownScale`
-|VOLUME_DOWN | - | Volume down by `upDownScale`
+|VOLUME_UP | upDownScale=Number | Volume up by `upDownScale`
+|VOLUME_DOWN | upDownScale=NUMBER | Volume down by `upDownScale`
 |VOLUME_STORE | `null` or `0-100` | Storing current volume and setting the volume to `number`.<br/> If payload be `null`, volume will not be changed. (just stored)
-|VOLUME_RESTORE | - | Setting volume with stored previously
+|VOLUME_RESTORE | faded=true or false; upDownScale=NUMBER | Setting volume with stored previously
 
 If volume is changed or `VOLUME_GET` is called, the current volume as result will be notified by `CURRENT_VOLUME` notification with `payload=0-100`.
 

--- a/package.json
+++ b/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "MMM-Volume",
+  "version": "0.0.1",
+  "description": "",
+  "main": "MMM-Volume.js",
+  "devDependencies": {},
+  "scripts": {},
+  "dependencies": {
+    "child_process": "^1.0.2"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:eouia/MMM-Volume.git"
+  },
+  "author": "eouia",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/eouia/MMM-Volume/issues"
+  },
+  "homepage": "https://github.com/eouia/MMM-Volume/#readme"
+}


### PR DESCRIPTION
Added the possibility to set the stepping for up and down in the payload of the notification;
Added a new notification VOLUME_TOGGLE which either sets the volume to 0 or restores it to the previously saved value;
Both VOLUME_RESTORE and VOLUME_TOGGLE are now support setting a "faded" option in the payload; if fading is enabled the volume will be increased / decreased step by step;
VOLUME_RESTORE and VOLUME_TOGGLE support setting the stepping in the payload like VOLUME_UP and VOLUME_DOWN now;
Added the example commands for Raspberry Pis using the HiFiBerry Amp2